### PR TITLE
Fix calling removeItem with ActionOnNodeRemoval.connectToParent has the same behavior of ActionOnNodeRemoval.unlink

### DIFF
--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -66,6 +66,8 @@ class OrgChartController<E> {
     assert(toSetter != null,
         "toSetter is not provided, you can't use this function without providing a toSetter");
 
+    final nodeToRemove =
+        _nodes.firstWhere((element) => idProvider(element.data) == id);
     final subnodes =
         _nodes.where((element) => toProvider(element.data) == id).toList();
 
@@ -75,12 +77,12 @@ class OrgChartController<E> {
           toSetter!(node.data, null);
           break;
         case ActionOnNodeRemoval.connectToParent:
-          toSetter!(node.data, toProvider(node.data));
+          toSetter!(node.data, toProvider(nodeToRemove.data));
           break;
       }
     }
 
-    _nodes.removeWhere((element) => idProvider(element.data) == id);
+    _nodes.remove(nodeToRemove);
     calculatePosition();
   }
 


### PR DESCRIPTION
Fixes #5 

**Description:**
This Pull Request fixes an issue where calling removeItem with ActionOnNodeRemoval.connectToParent behaves the same as calling it with ActionOnNodeRemoval.unlink.

**Changes:**
- Ensures that when ActionOnNodeRemoval.connectToParent is used, the removed node’s children correctly reconnect to its parent instead of being unlinked.
- Updates the logic to differentiate between the two actions properly.

**Purpose:**
This fix ensures that node removal behaves as expected, preserving the intended structure when connectToParent is specified.